### PR TITLE
fix: add direct path to homebrew icu4c formulae

### DIFF
--- a/lib/prawn/rtl/bidi.rb
+++ b/lib/prawn/rtl/bidi.rb
@@ -41,6 +41,7 @@ module Prawn
           else
             [
               '/usr/local/{lib64,lib}',
+              '/usr/local/opt/icu4c/{lib64,lib}',
               '/opt/local/{lib64,lib}',
               '/opt/homebrew/{lib64,lib}',
               '/usr/{lib64,lib}'


### PR DESCRIPTION
MacOS includes a built-in version of libicu(which includes only libicucore), so Homebrew won't link icu4c formulae